### PR TITLE
Improve interrupt handling timing

### DIFF
--- a/src/gameboy/cpu/disassembler/mod.rs
+++ b/src/gameboy/cpu/disassembler/mod.rs
@@ -1061,8 +1061,9 @@ fn dissassemble_x_3(y: u8, z: u8, p: u8, q: u8, opcode: u8) -> Instruction {
 
                 7 => {
                     let instruction_step = InstructionStep::Instant(Box::new(|cpu: &mut Cpu| {
-                        if !(*cpu.mmu).borrow_mut().interupts.is_master_enabled() {
+                        if !(*cpu.mmu).borrow_mut().interupts.is_master_enabled() && !cpu.ei_delay {
                             cpu.ei_delay = true;
+                            cpu.ei_delay_cycles = 4;
                         }
                     }));
                     steps.push_back(instruction_step);

--- a/src/gameboy/cpu/mod.rs
+++ b/src/gameboy/cpu/mod.rs
@@ -31,7 +31,7 @@ pub struct Cpu {
     operand8: u8,
     operand16: u16,
     pub temp_val8: u8,
-    temp_val_16: u16,
+    pub temp_val_16: u16,
 
     instruction: Option<Instruction>,
     machine_cycles_taken_for_current_step: u8,

--- a/src/gameboy/cpu/mod.rs
+++ b/src/gameboy/cpu/mod.rs
@@ -14,7 +14,7 @@ enum Flag {
 }
 
 pub struct Cpu {
-    mmu: Rc<RefCell<Mmu>>,
+    pub mmu: Rc<RefCell<Mmu>>,
 
     a: u8,
     b: u8,
@@ -25,12 +25,12 @@ pub struct Cpu {
     h: u8,
     l: u8,
 
-    pc: u16,
-    sp: u16,
+    pub pc: u16,
+    pub sp: u16,
 
     operand8: u8,
     operand16: u16,
-    temp_val8: u8,
+    pub temp_val8: u8,
     temp_val_16: u16,
 
     instruction: Option<Instruction>,
@@ -445,7 +445,7 @@ impl Cpu {
         (*self.mmu).borrow_mut().write_word(self.sp, val);
     }
 
-    fn write_byte_to_stack(&mut self, val: u8) {
+    pub(super) fn write_byte_to_stack(&mut self, val: u8) {
         self.sp = self.sp.wrapping_sub(1);
         (*self.mmu).borrow_mut().write_byte(self.sp, val);
     }

--- a/src/gameboy/interupt.rs
+++ b/src/gameboy/interupt.rs
@@ -137,11 +137,11 @@ impl Interupt {
         let mut steps: VecDeque<InstructionStep> = VecDeque::new();
 
         // NOP 1
-        let step = Box::new(|cpu: &mut Cpu| { });
+        let step = Box::new(|_cpu: &mut Cpu| { });
         steps.push_back(InstructionStep::Standard(step));
 
         // NOP 2
-        let step = Box::new(|cpu: &mut Cpu| { });
+        let step = Box::new(|_cpu: &mut Cpu| { });
         steps.push_back(InstructionStep::Standard(step));
 
         // push pc higher byte

--- a/src/gameboy/interupt.rs
+++ b/src/gameboy/interupt.rs
@@ -4,6 +4,10 @@ use super::{cpu::{Cpu, disassembler::{Instruction, InstructionStep}}};
 
 // https://eldred.fr/gb-asm-tutorial/interrupts.html
 
+// TODO:
+// Everything in this class should use some sort of state machine
+// "handling" interrupts is not instant. Every read should take 4-t cycles for example!
+
 pub struct Interupt {
     pub master: u8,
     pub enable: u8,

--- a/src/gameboy/interupt.rs
+++ b/src/gameboy/interupt.rs
@@ -102,7 +102,7 @@ impl Interupt {
     }
 
     pub fn handle(interrupt: &mut Interupt, cpu: &mut Cpu) {
-        if interrupt.is_master_enabled() && !cpu.is_processing_instruction() {
+        if interrupt.is_master_enabled() && (!cpu.is_processing_instruction() || cpu.is_fetching) {
             let _interrupt_flag = match interrupt.get_interupt_state() {
                 Some(flag) => flag,
                 None => return

--- a/src/gameboy/mod.rs
+++ b/src/gameboy/mod.rs
@@ -78,6 +78,11 @@ impl GameBoy {
     pub fn tick(&mut self) -> bool {
         if self.cpu.stopped { return true }
 
+        {
+            let mut mmu = (*self.mmu).borrow_mut();
+            Interupt::handle(&mut mmu.interupts, &mut self.cpu);
+        }
+
         self.cpu.tick();
         self.ppu.tick();
         
@@ -89,8 +94,6 @@ impl GameBoy {
         if request_timer_interupt {
             mmu.interupts.request_interupt(InterruptFlag::Timer)
         }
-
-        Interupt::handle(&mut mmu.interupts, &mut self.cpu);
 
         self.cpu.stopped
     }


### PR DESCRIPTION
https://www.reddit.com/r/EmuDev/comments/7206vh/sameboy_now_correctly_emulates_pinball_deluxe/

> Correct timing of IE and IF reads when an interrupt occurs. gekkio recently published a test that shows that the GB CPU reads IE twice when firing an interrupt – once when it checks if an interrupt occurred, and once when it checks which interrupt occured. These reads are not in the same M-Cycle. Turns out it is also true for the IF register, and this is exactly what happens in Pinball Deluxe: a VBlank interrupt occurs while the CPU handles a STAT interrupt; the VBlank interrupt effectively "hijacks" the routine and is handled before the STAT interrupt (because it has higher priority)

> T-cycle accurate interrupt timing. I recently discovered that the GB CPU reads IF in a different T-cycle when it's in halt mode. This means that some interrupts appear to be delayed by one M-cycle if they occur when the CPU is in halt mode. Which interrupts are "delayed" depend on the model: In CGB all tested interrupts (VBlank, STAT and Timer) are delayed when in halt mode. On DMG (Actually tested SGB2) VBlank is not delayed, Timer is delayed, and STAT depends on which STAT event trigger the interrupt (OAM interrupt is delayed, HBlank depends on SCX/Window/OAM, LYC isn't delayed, Vblank isn't delayed). For Pinball Deluxe to work when emulating both systems, VBlank, OAM and LYC interrupt T-cycle timings must be correct. Test ROMs to verify these behaviors will be released soon. This behavior also explains why CGB fails Mooneye-GB's intr_1_2_timing-GS and di_timing-GS.

See also: https://discord.com/channels/465585922579103744/465586075830845475/859181029779570708

> The IF&IE interrupt test happens on T3 after the fetch has started - which is why interrupt dispatch takes so long, it has to discard that fetch and decrement PC before pushing it and jumping to the interrupt handler

Apparently IE & IF "live in the cpu", in other words checking them is instant? See this exchange: https://discord.com/channels/465585922579103744/465586075830845475/859496176460890153

This maybe better explains the wording of the mooneye ie_push test: https://github.com/LIJI32/SameBoy/blob/master/Core/sm83_cpu.c#L1622#L1629

The goal of this MR is to pass the mooneye ie_push test ~~as well as being able to run Pinball Deluxe!~~
